### PR TITLE
Added an option to always render ic-modal-main.

### DIFF
--- a/lib/modal.js
+++ b/lib/modal.js
@@ -129,6 +129,26 @@ export default Ember.Component.extend({
   isOpen: false,
 
   /**
+   * Permanently renders the <ic-modal-main> into the dom
+   *
+   * @property alwaysRender
+   * @public
+   */
+
+  alwaysRender: false,
+
+  /**
+   * Determines whether <ic-modal-main> should be rendered.
+   *
+   * @property shouldRender
+   * @private
+   */
+
+  shouldRender: function() {
+    return this.get('alwaysRender') || this.get('isOpen');
+  }.property('isOpen', 'alwaysRender'),
+
+  /**
    * Opens the modal. Takes one option `{focus: false}`, which defaults
    * to false. If false it won't try to focus the dialog after it opens,
    * this is used when the modal is opened by a mouse click.

--- a/lib/templates/modal.hbs
+++ b/lib/templates/modal.hbs
@@ -1,4 +1,4 @@
-{{#if isOpen}}
+{{#if shouldRender}}
   <ic-modal-main>
 
     {{#if makeTitle}}


### PR DESCRIPTION
In order to add a closing css animation, the `ic-modal-main` tag must remain in the dom. I added an option, which when set to true will always render `ic-modal-main`.
