### PR TITLE
Fix dependencies

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -2,7 +2,7 @@ var moduleFilter = require('broccoli-dist-es6-module');
 var templateFilter = require('broccoli-template-compiler');
 
 module.exports = function(broccoli) {
-  var tree = broccoli.makeTree('lib');
+  var tree = 'lib';
   var templates = templateFilter(tree, {module: true});
   var modules = moduleFilter(templates, {
     global: 'ic.modal',

--- a/dist/named-amd/main.js
+++ b/dist/named-amd/main.js
@@ -29,7 +29,8 @@ define("ic-modal",
     __exports__.ModalTriggerComponent = ModalTriggerComponent;
     __exports__.ModalTitleComponent = ModalTitleComponent;
     __exports__.modalCss = modalCss;
-  });define("ic-modal/modal-form",
+  });
+define("ic-modal/modal-form",
   ["./modal","exports"],
   function(__dependency1__, __exports__) {
     "use strict";
@@ -143,7 +144,8 @@ define("ic-modal",
       }
 
     });
-  });define("ic-modal/modal-title",
+  });
+define("ic-modal/modal-title",
   ["ember","exports"],
   function(__dependency1__, __exports__) {
     "use strict";
@@ -174,7 +176,8 @@ define("ic-modal",
       }.on('willInsertElement')
         
     });
-  });define("ic-modal/modal-trigger",
+  });
+define("ic-modal/modal-trigger",
   ["ember","./modal","exports"],
   function(__dependency1__, __dependency2__, __exports__) {
     "use strict";
@@ -267,7 +270,8 @@ define("ic-modal",
       if (parent instanceof ModalComponent) return parent;
       return findParent(parent);
     }
-  });define("ic-modal/modal",
+  });
+define("ic-modal/modal",
   ["ember","exports"],
   function(__dependency1__, __exports__) {
     "use strict";
@@ -657,7 +661,8 @@ define("ic-modal",
       }
 
     });
-  });define("ic-modal/tabbable-selector",
+  });
+define("ic-modal/tabbable-selector",
   ["ember"],
   function(__dependency1__) {
     "use strict";
@@ -701,7 +706,8 @@ define("ic-modal",
         return ( isTabIndexNaN || tabIndex >= 0 ) && focusable( element, !isTabIndexNaN );
       }
     };
-  });define("ic-modal/templates/modal-css",
+  });
+define("ic-modal/templates/modal-css",
   ["ember","exports"],
   function(__dependency1__, __exports__) {
     "use strict";
@@ -715,7 +721,8 @@ define("ic-modal",
       data.buffer.push("ic-modal-screen,\nic-modal,\nic-modal-main,\nic-modal-title {\n  display: block;\n}\n\nic-modal,\n.ic-modal-form {\n  display: none;\n  -webkit-overflow-scrolling: touch;\n  position: fixed;\n  bottom: 0;\n  left: 0;\n  right: 0;\n  top: 0;\n  overflow: auto;\n  background-color: hsla(0, 0%, 100%, .90);\n  padding: 10px;\n}\n\nic-modal[is-open],\n.ic-modal-form[is-open] {\n  display: block;\n}\n\nic-modal-main {\n  position: relative;\n  margin: 40px auto;\n  max-width: 800px;\n  padding: 20px;\n  border-radius: 4px;\n  background: #fff;\n  border: 1px solid hsl(0, 0%, 70%);\n}\n\nic-modal-title {\n  margin: 0 -20px 20px -20px;\n  padding: 0 20px 20px 20px;\n  border-bottom: 1px solid hsl(0, 0%, 90%);\n}\n\n.ic-modal-trigger.ic-modal-close {\n  position: absolute;\n  right: 10px;\n  top: 10px;\n  background: none;\n  border: none;\n  color: inherit;\n  font-size: 18px;\n  padding: 6px;\n}\n\n.ic-modal-trigger.ic-modal-close:focus {\n  outline: none;\n  text-shadow: 0 0 6px hsl(208, 47%, 60%),\n    0 0 2px hsl(208, 47%, 60%),\n    0 0 2px hsl(208, 47%, 60%),\n    0 0 1px hsl(208, 47%, 60%);\n}\n\n");
       
     });
-  });define("ic-modal/templates/modal",
+  });
+define("ic-modal/templates/modal",
   ["ember","exports"],
   function(__dependency1__, __exports__) {
     "use strict";

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "devDependencies": {
     "bower": "^1.2.8",
-    "broccoli": "^0.2.0",
+    "broccoli": "^0.7.0",
     "qunitjs": "~1.12.0",
     "karma-qunit": "^0.1.1",
     "karma-script-launcher": "^0.1.0",
@@ -23,7 +23,7 @@
     "karma-firefox-launcher": "^0.1.3",
     "karma-html2js-preprocessor": "^0.1.0",
     "karma": "^0.10.9",
-    "broccoli-dist-es6-module": "^0.1.8",
+    "broccoli-dist-es6-module": "^0.2.0",
     "broccoli-cli": "0.0.1",
     "broccoli-template-compiler": "^1.4.1",
     "rf-release": "^0.1.2"


### PR DESCRIPTION
While trying to work on a PR for `ic-modal`, I've discovered that `npm install` would fail because of `broccoli` and `broccoli-dist-es6-module` versions.
