### PR TITLE
Add `close-on-click` and `close-on-escape` options

### DIFF
--- a/dist/amd/modal.js
+++ b/dist/amd/modal.js
@@ -231,13 +231,23 @@ define(
       },
 
       /**
+       * Sometimes we don’t want the user to close the modal
+       * just by pressing "escape"
+       *
+       * @property close-on-escape
+       * @public
+       */
+
+      'close-on-escape': true,
+
+      /**
        * @method handleKeyDown
        * @private
        */
 
       handleKeyDown: function(event) {
         if (event.keyCode == 9 /*tab*/) this.keepTabNavInside(event);
-        if (event.keyCode == 27 /*esc*/) this.close();
+        if (this.get('close-on-escape') && event.keyCode == 27 /*esc*/) this.close();
       }.on('keyDown'),
 
       /**
@@ -265,6 +275,16 @@ define(
       },
 
       /**
+       * Sometimes we don’t want the user to close the modal
+       * just by clicking the overlay
+       *
+       * @property close-on-click
+       * @public
+       */
+
+      'close-on-click': true,
+
+      /**
        * Clicking outside the dialog should close it. We don't need to
        * handle other forms of losing focus (like keyboard nav) because we
        * already handle all of the keyboard navigation when its open.
@@ -274,7 +294,7 @@ define(
        */
 
       closeOnClick: function(event) {
-        if (event.target !== this.get('element')) return;
+        if (!this.get('close-on-click') || event.target !== this.get('element')) return;
         this.close();
       }.on('click'),
 

--- a/dist/cjs/modal.js
+++ b/dist/cjs/modal.js
@@ -228,13 +228,23 @@ exports["default"] = Ember.Component.extend({
   },
 
   /**
+   * Sometimes we don’t want the user to close the modal
+   * just by pressing "escape"
+   *
+   * @property close-on-escape
+   * @public
+   */
+
+  'close-on-escape': true,
+
+  /**
    * @method handleKeyDown
    * @private
    */
 
   handleKeyDown: function(event) {
     if (event.keyCode == 9 /*tab*/) this.keepTabNavInside(event);
-    if (event.keyCode == 27 /*esc*/) this.close();
+    if (this.get('close-on-escape') && event.keyCode == 27 /*esc*/) this.close();
   }.on('keyDown'),
 
   /**
@@ -262,6 +272,16 @@ exports["default"] = Ember.Component.extend({
   },
 
   /**
+   * Sometimes we don’t want the user to close the modal
+   * just by clicking the overlay
+   *
+   * @property close-on-click
+   * @public
+   */
+
+  'close-on-click': true,
+
+  /**
    * Clicking outside the dialog should close it. We don't need to
    * handle other forms of losing focus (like keyboard nav) because we
    * already handle all of the keyboard navigation when its open.
@@ -271,7 +291,7 @@ exports["default"] = Ember.Component.extend({
    */
 
   closeOnClick: function(event) {
-    if (event.target !== this.get('element')) return;
+    if (!this.get('close-on-click') || event.target !== this.get('element')) return;
     this.close();
   }.on('click'),
 

--- a/dist/globals/main.js
+++ b/dist/globals/main.js
@@ -490,13 +490,23 @@ exports["default"] = Ember.Component.extend({
   },
 
   /**
+   * Sometimes we don’t want the user to close the modal
+   * just by pressing "escape"
+   *
+   * @property close-on-escape
+   * @public
+   */
+
+  'close-on-escape': true,
+
+  /**
    * @method handleKeyDown
    * @private
    */
 
   handleKeyDown: function(event) {
     if (event.keyCode == 9 /*tab*/) this.keepTabNavInside(event);
-    if (event.keyCode == 27 /*esc*/) this.close();
+    if (this.get('close-on-escape') && event.keyCode == 27 /*esc*/) this.close();
   }.on('keyDown'),
 
   /**
@@ -524,6 +534,16 @@ exports["default"] = Ember.Component.extend({
   },
 
   /**
+   * Sometimes we don’t want the user to close the modal
+   * just by clicking the overlay
+   *
+   * @property close-on-click
+   * @public
+   */
+
+  'close-on-click': true,
+
+  /**
    * Clicking outside the dialog should close it. We don't need to
    * handle other forms of losing focus (like keyboard nav) because we
    * already handle all of the keyboard navigation when its open.
@@ -533,7 +553,7 @@ exports["default"] = Ember.Component.extend({
    */
 
   closeOnClick: function(event) {
-    if (event.target !== this.get('element')) return;
+    if (!this.get('close-on-click') || event.target !== this.get('element')) return;
     this.close();
   }.on('click'),
 

--- a/dist/named-amd/main.js
+++ b/dist/named-amd/main.js
@@ -504,13 +504,23 @@ define("ic-modal/modal",
       },
 
       /**
+       * Sometimes we don’t want the user to close the modal
+       * just by pressing "escape"
+       *
+       * @property close-on-escape
+       * @public
+       */
+
+      'close-on-escape': true,
+
+      /**
        * @method handleKeyDown
        * @private
        */
 
       handleKeyDown: function(event) {
         if (event.keyCode == 9 /*tab*/) this.keepTabNavInside(event);
-        if (event.keyCode == 27 /*esc*/) this.close();
+        if (this.get('close-on-escape') && event.keyCode == 27 /*esc*/) this.close();
       }.on('keyDown'),
 
       /**
@@ -538,6 +548,16 @@ define("ic-modal/modal",
       },
 
       /**
+       * Sometimes we don’t want the user to close the modal
+       * just by clicking the overlay
+       *
+       * @property close-on-click
+       * @public
+       */
+
+      'close-on-click': true,
+
+      /**
        * Clicking outside the dialog should close it. We don't need to
        * handle other forms of losing focus (like keyboard nav) because we
        * already handle all of the keyboard navigation when its open.
@@ -547,7 +567,7 @@ define("ic-modal/modal",
        */
 
       closeOnClick: function(event) {
-        if (event.target !== this.get('element')) return;
+        if (!this.get('close-on-click') || event.target !== this.get('element')) return;
         this.close();
       }.on('click'),
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -17,6 +17,8 @@
 
 {{#ic-modal
   id="the-modal"
+  close-on-click=false
+  close-on-escape=false
   close-when=formWasSubmitted
   open-when=startFeatureTour
 }}

--- a/lib/modal.js
+++ b/lib/modal.js
@@ -227,13 +227,23 @@ export default Ember.Component.extend({
   },
 
   /**
+   * Sometimes we don’t want the user to close the modal
+   * just by pressing "escape"
+   *
+   * @property close-on-escape
+   * @public
+   */
+
+  'close-on-escape': true,
+
+  /**
    * @method handleKeyDown
    * @private
    */
 
   handleKeyDown: function(event) {
     if (event.keyCode == 9 /*tab*/) this.keepTabNavInside(event);
-    if (event.keyCode == 27 /*esc*/) this.close();
+    if (this.get('close-on-escape') && event.keyCode == 27 /*esc*/) this.close();
   }.on('keyDown'),
 
   /**
@@ -261,6 +271,16 @@ export default Ember.Component.extend({
   },
 
   /**
+   * Sometimes we don’t want the user to close the modal
+   * just by clicking the overlay
+   *
+   * @property close-on-click
+   * @public
+   */
+
+  'close-on-click': true,
+
+  /**
    * Clicking outside the dialog should close it. We don't need to
    * handle other forms of losing focus (like keyboard nav) because we
    * already handle all of the keyboard navigation when its open.
@@ -270,7 +290,7 @@ export default Ember.Component.extend({
    */
 
   closeOnClick: function(event) {
-    if (event.target !== this.get('element')) return;
+    if (!this.get('close-on-click') || event.target !== this.get('element')) return;
     this.close();
   }.on('click'),
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "devDependencies": {
     "bower": "^1.2.8",
-    "broccoli": "^0.7.0",
+    "broccoli": "^0.7.1",
     "qunitjs": "~1.12.0",
     "karma-qunit": "^0.1.1",
     "karma-script-launcher": "^0.1.0",


### PR DESCRIPTION
I wanted to use `ic-modal` to do confirmation dialogs in my app and closing the modal without using the actual buttons wasn’t working, so I added options to configure it. The default is still to close when clicking the overlay or pressing escape.

PS. I also fixed the build to be able to do this PR, tell me if you ever merge https://github.com/instructure/ic-modal/pull/12 so I can rebase master.
