### PR TITLE
Allow overriding of "controls" attribute on nested ic-modal-triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,10 @@ Here are all the bells and whistles:
   {{#ic-modal-title}}Tacos{{/ic-modal-title}}
 
   <!--
-    If a trigger lives inside a modal it doesn't need a "controls"
-    attribute, it'll just know.
+    If a trigger lives inside a modal you can optionally pass a  "controls"
+    attribute. When omitted, the trigger will default to the modal it is
+    contained within. You can override this behavior by passing a new
+    controls attribute (for example: if you wanted to spawn a different modal).
 
     If you don't provide a trigger inside the modal, you'll get one
     automatically, but if you're translating, you're going to want your

--- a/dist/amd/modal-trigger.js
+++ b/dist/amd/modal-trigger.js
@@ -45,7 +45,7 @@ define(
 
       findModal: function() {
         var parent = findParent(this);
-        if (parent) {
+        if (parent && !this.get('controls')) {
           // we don't care about "controls" if we are child
           this.set('modal', parent);
           parent.registerTrigger(this);

--- a/dist/amd/modal-trigger.js
+++ b/dist/amd/modal-trigger.js
@@ -37,7 +37,8 @@ define(
 
       /**
        * Finds the modal this element controls. If a trigger is a child of
-       * the modal, you do not need to specify a "controls" attribute.
+       * the modal, you can optionally pass a "controls" attribute.
+       * It will default to the parent modal if not specified.
        *
        * @method findModal
        * @private
@@ -46,7 +47,8 @@ define(
       findModal: function() {
         var parent = findParent(this);
         if (parent && !this.get('controls')) {
-          // we don't care about "controls" if we are child
+          // default "controls" to the parent modal if we are a child
+          // and no override is specified
           this.set('modal', parent);
           parent.registerTrigger(this);
         } else {

--- a/dist/cjs/modal-trigger.js
+++ b/dist/cjs/modal-trigger.js
@@ -34,7 +34,8 @@ exports["default"] = Ember.Component.extend({
 
   /**
    * Finds the modal this element controls. If a trigger is a child of
-   * the modal, you do not need to specify a "controls" attribute.
+   * the modal, you can optionally pass a "controls" attribute.
+   * It will default to the parent modal if not specified.
    *
    * @method findModal
    * @private
@@ -43,7 +44,8 @@ exports["default"] = Ember.Component.extend({
   findModal: function() {
     var parent = findParent(this);
     if (parent && !this.get('controls')) {
-      // we don't care about "controls" if we are child
+      // default "controls" to the parent modal if we are a child
+      // and no override is specified
       this.set('modal', parent);
       parent.registerTrigger(this);
     } else {

--- a/dist/cjs/modal-trigger.js
+++ b/dist/cjs/modal-trigger.js
@@ -42,7 +42,7 @@ exports["default"] = Ember.Component.extend({
 
   findModal: function() {
     var parent = findParent(this);
-    if (parent) {
+    if (parent && !this.get('controls')) {
       // we don't care about "controls" if we are child
       this.set('modal', parent);
       parent.registerTrigger(this);

--- a/dist/globals/main.js
+++ b/dist/globals/main.js
@@ -205,7 +205,8 @@ exports["default"] = Ember.Component.extend({
 
   /**
    * Finds the modal this element controls. If a trigger is a child of
-   * the modal, you do not need to specify a "controls" attribute.
+   * the modal, you can optionally pass a "controls" attribute.
+   * It will default to the parent modal if not specified.
    *
    * @method findModal
    * @private
@@ -214,7 +215,8 @@ exports["default"] = Ember.Component.extend({
   findModal: function() {
     var parent = findParent(this);
     if (parent && !this.get('controls')) {
-      // we don't care about "controls" if we are child
+      // default "controls" to the parent modal if we are a child
+      // and no override is specified
       this.set('modal', parent);
       parent.registerTrigger(this);
     } else {

--- a/dist/globals/main.js
+++ b/dist/globals/main.js
@@ -213,7 +213,7 @@ exports["default"] = Ember.Component.extend({
 
   findModal: function() {
     var parent = findParent(this);
-    if (parent) {
+    if (parent && !this.get('controls')) {
       // we don't care about "controls" if we are child
       this.set('modal', parent);
       parent.registerTrigger(this);

--- a/dist/named-amd/main.js
+++ b/dist/named-amd/main.js
@@ -224,7 +224,7 @@ define("ic-modal/modal-trigger",
 
       findModal: function() {
         var parent = findParent(this);
-        if (parent) {
+        if (parent && !this.get('controls')) {
           // we don't care about "controls" if we are child
           this.set('modal', parent);
           parent.registerTrigger(this);

--- a/dist/named-amd/main.js
+++ b/dist/named-amd/main.js
@@ -216,7 +216,8 @@ define("ic-modal/modal-trigger",
 
       /**
        * Finds the modal this element controls. If a trigger is a child of
-       * the modal, you do not need to specify a "controls" attribute.
+       * the modal, you can optionally pass a "controls" attribute.
+       * It will default to the parent modal if not specified.
        *
        * @method findModal
        * @private
@@ -225,7 +226,8 @@ define("ic-modal/modal-trigger",
       findModal: function() {
         var parent = findParent(this);
         if (parent && !this.get('controls')) {
-          // we don't care about "controls" if we are child
+          // default "controls" to the parent modal if we are a child
+          // and no override is specified
           this.set('modal', parent);
           parent.registerTrigger(this);
         } else {

--- a/lib/modal-trigger.js
+++ b/lib/modal-trigger.js
@@ -33,7 +33,8 @@ export default Ember.Component.extend({
 
   /**
    * Finds the modal this element controls. If a trigger is a child of
-   * the modal, you do not need to specify a "controls" attribute.
+   * the modal, you can optionally pass a "controls" attribute.
+   * It will default to the parent modal if not specified.
    *
    * @method findModal
    * @private
@@ -42,7 +43,8 @@ export default Ember.Component.extend({
   findModal: function() {
     var parent = findParent(this);
     if (parent && !this.get('controls')) {
-      // we don't care about "controls" if we are child
+      // default "controls" to the parent modal if we are a child
+      // and no override is specified
       this.set('modal', parent);
       parent.registerTrigger(this);
     } else {

--- a/lib/modal-trigger.js
+++ b/lib/modal-trigger.js
@@ -41,7 +41,7 @@ export default Ember.Component.extend({
 
   findModal: function() {
     var parent = findParent(this);
-    if (parent) {
+    if (parent && !this.get('controls')) {
       // we don't care about "controls" if we are child
       this.set('modal', parent);
       parent.registerTrigger(this);


### PR DESCRIPTION
We came across a use-case where an existing modal needed to contain a trigger for another modal. Because any modal trigger inside a modal was assumed to trigger its container, we needed to allow specifying a different modal to trigger.
