### PR TITLE
Add guard for destroyed modal in handleTabIntoBrowser

### DIFF
--- a/dist/amd/modal.js
+++ b/dist/amd/modal.js
@@ -20,7 +20,7 @@ define(
     Ember.$(document).on('focusin', handleTabIntoBrowser);
 
     function handleTabIntoBrowser(event) {
-      if (!lastOpenedModal) return;
+      if (!lastOpenedModal || lastOpenedModal.get('isDestroyed')) return;
       lastOpenedModal.focus();
     }
 

--- a/dist/cjs/modal.js
+++ b/dist/cjs/modal.js
@@ -17,7 +17,7 @@ var lastOpenedModal = null;
 Ember.$(document).on('focusin', handleTabIntoBrowser);
 
 function handleTabIntoBrowser(event) {
-  if (!lastOpenedModal) return;
+  if (!lastOpenedModal || lastOpenedModal.get('isDestroyed')) return;
   lastOpenedModal.focus();
 }
 

--- a/dist/globals/main.js
+++ b/dist/globals/main.js
@@ -279,7 +279,7 @@ var lastOpenedModal = null;
 Ember.$(document).on('focusin', handleTabIntoBrowser);
 
 function handleTabIntoBrowser(event) {
-  if (!lastOpenedModal) return;
+  if (!lastOpenedModal || lastOpenedModal.get('isDestroyed')) return;
   lastOpenedModal.focus();
 }
 

--- a/dist/named-amd/main.js
+++ b/dist/named-amd/main.js
@@ -293,7 +293,7 @@ define("ic-modal/modal",
     Ember.$(document).on('focusin', handleTabIntoBrowser);
 
     function handleTabIntoBrowser(event) {
-      if (!lastOpenedModal) return;
+      if (!lastOpenedModal || lastOpenedModal.get('isDestroyed')) return;
       lastOpenedModal.focus();
     }
 

--- a/lib/modal.js
+++ b/lib/modal.js
@@ -16,7 +16,7 @@ var lastOpenedModal = null;
 Ember.$(document).on('focusin', handleTabIntoBrowser);
 
 function handleTabIntoBrowser(event) {
-  if (!lastOpenedModal) return;
+  if (!lastOpenedModal || lastOpenedModal.get('isDestroyed')) return;
   lastOpenedModal.focus();
 }
 


### PR DESCRIPTION
This PR adds a guard to handleTabIntoBrowser to do an early return if
the modal is in a destroyed state.

During our integration tests, our teardown hook was destroying the app
instance but we weren't explicitly closing the modal. When we were
hitting our subsequent tests, ic-modal was trying to focus in on the
modal even though it was in a destroyed state. While we're now making
sure we explicitly close the modal in our teardown hook, it feels like
ic-modal should internally handle this and guard against trying to focus
on a destroyed modal.
