### PR TITLE
Support iOS Safari browsers clicking to dismiss modal

### DIFF
--- a/lib/modal.js
+++ b/lib/modal.js
@@ -94,7 +94,7 @@ export default Ember.Component.extend({
    * @private
    */
   
-  onclick: '/* no-op for iOS Safari */'
+  onclick: '/* no-op for iOS Safari */',
 
   /**
    * Tells the screenreader not to read this when closed.

--- a/lib/modal.js
+++ b/lib/modal.js
@@ -39,7 +39,8 @@ export default Ember.Component.extend({
     'aria-labelledby',
     'is-open',
     'role',
-    'tabindex'
+    'tabindex',
+    'onclick'
   ],
 
   /**
@@ -77,6 +78,23 @@ export default Ember.Component.extend({
    */
 
   tabindex: 0,
+
+  /**
+   * iOS browsers will only generate a click event when a particular DOM
+   * element has a specific binding to it or if it has `cursor: pointer`
+   * styling applied to it.
+   * 
+   * Ember's `.on('click')` is not sufficient for iOS' browsers, so
+   * using the `onclick` attribute on the modal DOM element is used.
+   * 
+   * The contents is a noop, but it will still cause iOS browsers to
+   * generate a click event, to which `closeOnClick` will respond to.
+   * 
+   * @property onclick
+   * @private
+   */
+  
+  onclick: '/* no-op for iOS Safari */'
 
   /**
    * Tells the screenreader not to read this when closed.


### PR DESCRIPTION
iOS browsers will only generate a click event when a particular DOM element has a specific binding to it or if it has `cursor: pointer` styling applied to it.

Ember's `.on('click')` is not sufficient for iOS' browsers, so using the `onclick` attribute on the modal DOM element is used.

The contents is a noop, but it will still cause iOS browsers to generate a click event, to which `closeOnClick` will respond to.
