### PR TITLE
Enable usage of ic-modal with Ember 1.9.0.

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -1,7 +1,8 @@
 var makeModules = require('broccoli-dist-es6-module');
-var templateFilter = require('broccoli-template-compiler');
+var templateFilter = require('broccoli-ember-hbs-template-compiler');
 
 var templates = templateFilter('lib', {module: true});
+
 module.exports = makeModules(templates, {
   global: 'ic.modal',
   packageName: 'ic-modal',

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ic-modal",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "authors": [
     "Ryan Florence <rpflorence@gmail.com>"
   ],

--- a/dist/amd/templates/modal-css.js
+++ b/dist/amd/templates/modal-css.js
@@ -3,13 +3,7 @@ define(
   function(__dependency1__, __exports__) {
     "use strict";
     var Ember = __dependency1__["default"] || __dependency1__;
-    __exports__["default"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
-    this.compilerInfo = [4,'>= 1.0.0'];
-    helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
-      
-
-
+    __exports__["default"] = Ember.Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
       data.buffer.push("ic-modal-screen,\nic-modal,\nic-modal-main,\nic-modal-title {\n  display: block;\n}\n\nic-modal,\n.ic-modal-form {\n  display: none;\n  -webkit-overflow-scrolling: touch;\n  position: fixed;\n  bottom: 0;\n  left: 0;\n  right: 0;\n  top: 0;\n  overflow: auto;\n  background-color: hsla(0, 0%, 100%, .90);\n  padding: 10px;\n}\n\nic-modal[is-open],\n.ic-modal-form[is-open] {\n  display: block;\n}\n\nic-modal-main {\n  position: relative;\n  margin: 40px auto;\n  max-width: 800px;\n  padding: 20px;\n  border-radius: 4px;\n  background: #fff;\n  border: 1px solid hsl(0, 0%, 70%);\n}\n\nic-modal-title {\n  margin: 0 -20px 20px -20px;\n  padding: 0 20px 20px 20px;\n  border-bottom: 1px solid hsl(0, 0%, 90%);\n}\n\n.ic-modal-trigger.ic-modal-close {\n  position: absolute;\n  right: 10px;\n  top: 10px;\n  background: none;\n  border: none;\n  color: inherit;\n  font-size: 18px;\n  padding: 6px;\n}\n\n.ic-modal-trigger.ic-modal-close:focus {\n  outline: none;\n  text-shadow: 0 0 6px hsl(208, 47%, 60%),\n    0 0 2px hsl(208, 47%, 60%),\n    0 0 2px hsl(208, 47%, 60%),\n    0 0 1px hsl(208, 47%, 60%);\n}\n\n");
-      
-    });
+      },"useData":true});
   });

--- a/dist/amd/templates/modal.js
+++ b/dist/amd/templates/modal.js
@@ -3,66 +3,46 @@ define(
   function(__dependency1__, __exports__) {
     "use strict";
     var Ember = __dependency1__["default"] || __dependency1__;
-    __exports__["default"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
-    this.compilerInfo = [4,'>= 1.0.0'];
-    helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
-      var buffer = '', stack1, self=this, functionType="function", blockHelperMissing=helpers.blockHelperMissing, helperMissing=helpers.helperMissing;
-
-    function program1(depth0,data) {
-      
-      var buffer = '', stack1;
-      data.buffer.push("\n  <ic-modal-main>\n\n    ");
-      stack1 = helpers['if'].call(depth0, "makeTitle", {hash:{},hashTypes:{},hashContexts:{},inverse:self.noop,fn:self.program(2, program2, data),contexts:[depth0],types:["ID"],data:data});
-      if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
-      data.buffer.push("\n\n    ");
-      stack1 = helpers['if'].call(depth0, "makeTrigger", {hash:{},hashTypes:{},hashContexts:{},inverse:self.noop,fn:self.program(5, program5, data),contexts:[depth0],types:["ID"],data:data});
-      if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
-      data.buffer.push("\n\n    ");
-      stack1 = helpers._triageMustache.call(depth0, "yield", {hash:{},hashTypes:{},hashContexts:{},contexts:[depth0],types:["ID"],data:data});
-      if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
+    __exports__["default"] = Ember.Handlebars.template({"1":function(depth0,helpers,partials,data) {
+      var stack1, buffer = '';
+      data.buffer.push("  <ic-modal-main>\n\n");
+      stack1 = helpers['if'].call(depth0, "makeTitle", {"name":"if","hash":{},"hashTypes":{},"hashContexts":{},"fn":this.program(2, data),"inverse":this.noop,"types":["ID"],"contexts":[depth0],"data":data});
+      if (stack1 != null) { data.buffer.push(stack1); }
+      data.buffer.push("\n");
+      stack1 = helpers['if'].call(depth0, "makeTrigger", {"name":"if","hash":{},"hashTypes":{},"hashContexts":{},"fn":this.program(5, data),"inverse":this.noop,"types":["ID"],"contexts":[depth0],"data":data});
+      if (stack1 != null) { data.buffer.push(stack1); }
+      data.buffer.push("\n    ");
+      stack1 = helpers._triageMustache.call(depth0, "yield", {"name":"_triageMustache","hash":{},"hashTypes":{},"hashContexts":{},"types":["ID"],"contexts":[depth0],"data":data});
+      if (stack1 != null) { data.buffer.push(stack1); }
       data.buffer.push("\n\n  </ic-modal-main>\n");
       return buffer;
-      }
-    function program2(depth0,data) {
-      
-      var buffer = '', stack1, helper, options;
-      data.buffer.push("\n      ");
-      options={hash:{},hashTypes:{},hashContexts:{},inverse:self.noop,fn:self.program(3, program3, data),contexts:[],types:[],data:data}
-      if (helper = helpers['ic-modal-title']) { stack1 = helper.call(depth0, options); }
-      else { helper = (depth0 && depth0['ic-modal-title']); stack1 = typeof helper === functionType ? helper.call(depth0, options) : helper; }
-      if (!helpers['ic-modal-title']) { stack1 = blockHelperMissing.call(depth0, 'ic-modal-title', {hash:{},hashTypes:{},hashContexts:{},inverse:self.noop,fn:self.program(3, program3, data),contexts:[],types:[],data:data}); }
-      if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
-      data.buffer.push("\n    ");
+    },"2":function(depth0,helpers,partials,data) {
+      var stack1, helper, options, functionType="function", helperMissing=helpers.helperMissing, blockHelperMissing=helpers.blockHelperMissing, buffer = '';
+      data.buffer.push("      ");
+      stack1 = ((helper = (helper = helpers['ic-modal-title'] || (depth0 != null ? depth0['ic-modal-title'] : depth0)) != null ? helper : helperMissing),(options={"name":"ic-modal-title","hash":{},"hashTypes":{},"hashContexts":{},"fn":this.program(3, data),"inverse":this.noop,"types":[],"contexts":[],"data":data}),(typeof helper === functionType ? helper.call(depth0, options) : helper));
+      if (!helpers['ic-modal-title']) { stack1 = blockHelperMissing.call(depth0, stack1, options); }
+      if (stack1 != null) { data.buffer.push(stack1); }
+      data.buffer.push("\n");
       return buffer;
-      }
-    function program3(depth0,data) {
-      
-      
+    },"3":function(depth0,helpers,partials,data) {
       data.buffer.push("Modal Content");
-      }
-
-    function program5(depth0,data) {
-      
-      var buffer = '', stack1, helper, options;
-      data.buffer.push("\n      ");
-      stack1 = (helper = helpers['ic-modal-trigger'] || (depth0 && depth0['ic-modal-trigger']),options={hash:{
-        'class': ("ic-modal-close"),
-        'aria-label': ("close")
-      },hashTypes:{'class': "STRING",'aria-label': "STRING"},hashContexts:{'class': depth0,'aria-label': depth0},inverse:self.noop,fn:self.program(6, program6, data),contexts:[],types:[],data:data},helper ? helper.call(depth0, options) : helperMissing.call(depth0, "ic-modal-trigger", options));
-      if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
-      data.buffer.push("\n    ");
+      },"5":function(depth0,helpers,partials,data) {
+      var stack1, helperMissing=helpers.helperMissing, buffer = '';
+      data.buffer.push("      ");
+      stack1 = ((helpers['ic-modal-trigger'] || (depth0 && depth0['ic-modal-trigger']) || helperMissing).call(depth0, {"name":"ic-modal-trigger","hash":{
+        'aria-label': ("close"),
+        'class': ("ic-modal-close")
+      },"hashTypes":{'aria-label': "STRING",'class': "STRING"},"hashContexts":{'aria-label': depth0,'class': depth0},"fn":this.program(6, data),"inverse":this.noop,"types":[],"contexts":[],"data":data}));
+      if (stack1 != null) { data.buffer.push(stack1); }
+      data.buffer.push("\n");
       return buffer;
-      }
-    function program6(depth0,data) {
-      
-      
+    },"6":function(depth0,helpers,partials,data) {
       data.buffer.push("×");
-      }
-
-      stack1 = helpers['if'].call(depth0, "isOpen", {hash:{},hashTypes:{},hashContexts:{},inverse:self.noop,fn:self.program(1, program1, data),contexts:[depth0],types:["ID"],data:data});
-      if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
-      data.buffer.push("\n\n");
+      },"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
+      var stack1, buffer = '';
+      stack1 = helpers['if'].call(depth0, "isOpen", {"name":"if","hash":{},"hashTypes":{},"hashContexts":{},"fn":this.program(1, data),"inverse":this.noop,"types":["ID"],"contexts":[depth0],"data":data});
+      if (stack1 != null) { data.buffer.push(stack1); }
+      data.buffer.push("\n");
       return buffer;
-      
-    });
+    },"useData":true});
   });

--- a/dist/cjs/templates/modal-css.js
+++ b/dist/cjs/templates/modal-css.js
@@ -1,11 +1,5 @@
 "use strict";
 var Ember = require("ember")["default"] || require("ember");
-exports["default"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
-this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
-  
-
-
+exports["default"] = Ember.Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   data.buffer.push("ic-modal-screen,\nic-modal,\nic-modal-main,\nic-modal-title {\n  display: block;\n}\n\nic-modal,\n.ic-modal-form {\n  display: none;\n  -webkit-overflow-scrolling: touch;\n  position: fixed;\n  bottom: 0;\n  left: 0;\n  right: 0;\n  top: 0;\n  overflow: auto;\n  background-color: hsla(0, 0%, 100%, .90);\n  padding: 10px;\n}\n\nic-modal[is-open],\n.ic-modal-form[is-open] {\n  display: block;\n}\n\nic-modal-main {\n  position: relative;\n  margin: 40px auto;\n  max-width: 800px;\n  padding: 20px;\n  border-radius: 4px;\n  background: #fff;\n  border: 1px solid hsl(0, 0%, 70%);\n}\n\nic-modal-title {\n  margin: 0 -20px 20px -20px;\n  padding: 0 20px 20px 20px;\n  border-bottom: 1px solid hsl(0, 0%, 90%);\n}\n\n.ic-modal-trigger.ic-modal-close {\n  position: absolute;\n  right: 10px;\n  top: 10px;\n  background: none;\n  border: none;\n  color: inherit;\n  font-size: 18px;\n  padding: 6px;\n}\n\n.ic-modal-trigger.ic-modal-close:focus {\n  outline: none;\n  text-shadow: 0 0 6px hsl(208, 47%, 60%),\n    0 0 2px hsl(208, 47%, 60%),\n    0 0 2px hsl(208, 47%, 60%),\n    0 0 1px hsl(208, 47%, 60%);\n}\n\n");
-  
-});
+  },"useData":true});

--- a/dist/cjs/templates/modal.js
+++ b/dist/cjs/templates/modal.js
@@ -1,64 +1,44 @@
 "use strict";
 var Ember = require("ember")["default"] || require("ember");
-exports["default"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
-this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
-  var buffer = '', stack1, self=this, functionType="function", blockHelperMissing=helpers.blockHelperMissing, helperMissing=helpers.helperMissing;
-
-function program1(depth0,data) {
-  
-  var buffer = '', stack1;
-  data.buffer.push("\n  <ic-modal-main>\n\n    ");
-  stack1 = helpers['if'].call(depth0, "makeTitle", {hash:{},hashTypes:{},hashContexts:{},inverse:self.noop,fn:self.program(2, program2, data),contexts:[depth0],types:["ID"],data:data});
-  if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
-  data.buffer.push("\n\n    ");
-  stack1 = helpers['if'].call(depth0, "makeTrigger", {hash:{},hashTypes:{},hashContexts:{},inverse:self.noop,fn:self.program(5, program5, data),contexts:[depth0],types:["ID"],data:data});
-  if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
-  data.buffer.push("\n\n    ");
-  stack1 = helpers._triageMustache.call(depth0, "yield", {hash:{},hashTypes:{},hashContexts:{},contexts:[depth0],types:["ID"],data:data});
-  if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
+exports["default"] = Ember.Handlebars.template({"1":function(depth0,helpers,partials,data) {
+  var stack1, buffer = '';
+  data.buffer.push("  <ic-modal-main>\n\n");
+  stack1 = helpers['if'].call(depth0, "makeTitle", {"name":"if","hash":{},"hashTypes":{},"hashContexts":{},"fn":this.program(2, data),"inverse":this.noop,"types":["ID"],"contexts":[depth0],"data":data});
+  if (stack1 != null) { data.buffer.push(stack1); }
+  data.buffer.push("\n");
+  stack1 = helpers['if'].call(depth0, "makeTrigger", {"name":"if","hash":{},"hashTypes":{},"hashContexts":{},"fn":this.program(5, data),"inverse":this.noop,"types":["ID"],"contexts":[depth0],"data":data});
+  if (stack1 != null) { data.buffer.push(stack1); }
+  data.buffer.push("\n    ");
+  stack1 = helpers._triageMustache.call(depth0, "yield", {"name":"_triageMustache","hash":{},"hashTypes":{},"hashContexts":{},"types":["ID"],"contexts":[depth0],"data":data});
+  if (stack1 != null) { data.buffer.push(stack1); }
   data.buffer.push("\n\n  </ic-modal-main>\n");
   return buffer;
-  }
-function program2(depth0,data) {
-  
-  var buffer = '', stack1, helper, options;
-  data.buffer.push("\n      ");
-  options={hash:{},hashTypes:{},hashContexts:{},inverse:self.noop,fn:self.program(3, program3, data),contexts:[],types:[],data:data}
-  if (helper = helpers['ic-modal-title']) { stack1 = helper.call(depth0, options); }
-  else { helper = (depth0 && depth0['ic-modal-title']); stack1 = typeof helper === functionType ? helper.call(depth0, options) : helper; }
-  if (!helpers['ic-modal-title']) { stack1 = blockHelperMissing.call(depth0, 'ic-modal-title', {hash:{},hashTypes:{},hashContexts:{},inverse:self.noop,fn:self.program(3, program3, data),contexts:[],types:[],data:data}); }
-  if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
-  data.buffer.push("\n    ");
+},"2":function(depth0,helpers,partials,data) {
+  var stack1, helper, options, functionType="function", helperMissing=helpers.helperMissing, blockHelperMissing=helpers.blockHelperMissing, buffer = '';
+  data.buffer.push("      ");
+  stack1 = ((helper = (helper = helpers['ic-modal-title'] || (depth0 != null ? depth0['ic-modal-title'] : depth0)) != null ? helper : helperMissing),(options={"name":"ic-modal-title","hash":{},"hashTypes":{},"hashContexts":{},"fn":this.program(3, data),"inverse":this.noop,"types":[],"contexts":[],"data":data}),(typeof helper === functionType ? helper.call(depth0, options) : helper));
+  if (!helpers['ic-modal-title']) { stack1 = blockHelperMissing.call(depth0, stack1, options); }
+  if (stack1 != null) { data.buffer.push(stack1); }
+  data.buffer.push("\n");
   return buffer;
-  }
-function program3(depth0,data) {
-  
-  
+},"3":function(depth0,helpers,partials,data) {
   data.buffer.push("Modal Content");
-  }
-
-function program5(depth0,data) {
-  
-  var buffer = '', stack1, helper, options;
-  data.buffer.push("\n      ");
-  stack1 = (helper = helpers['ic-modal-trigger'] || (depth0 && depth0['ic-modal-trigger']),options={hash:{
-    'class': ("ic-modal-close"),
-    'aria-label': ("close")
-  },hashTypes:{'class': "STRING",'aria-label': "STRING"},hashContexts:{'class': depth0,'aria-label': depth0},inverse:self.noop,fn:self.program(6, program6, data),contexts:[],types:[],data:data},helper ? helper.call(depth0, options) : helperMissing.call(depth0, "ic-modal-trigger", options));
-  if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
-  data.buffer.push("\n    ");
+  },"5":function(depth0,helpers,partials,data) {
+  var stack1, helperMissing=helpers.helperMissing, buffer = '';
+  data.buffer.push("      ");
+  stack1 = ((helpers['ic-modal-trigger'] || (depth0 && depth0['ic-modal-trigger']) || helperMissing).call(depth0, {"name":"ic-modal-trigger","hash":{
+    'aria-label': ("close"),
+    'class': ("ic-modal-close")
+  },"hashTypes":{'aria-label': "STRING",'class': "STRING"},"hashContexts":{'aria-label': depth0,'class': depth0},"fn":this.program(6, data),"inverse":this.noop,"types":[],"contexts":[],"data":data}));
+  if (stack1 != null) { data.buffer.push(stack1); }
+  data.buffer.push("\n");
   return buffer;
-  }
-function program6(depth0,data) {
-  
-  
+},"6":function(depth0,helpers,partials,data) {
   data.buffer.push("×");
-  }
-
-  stack1 = helpers['if'].call(depth0, "isOpen", {hash:{},hashTypes:{},hashContexts:{},inverse:self.noop,fn:self.program(1, program1, data),contexts:[depth0],types:["ID"],data:data});
-  if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
-  data.buffer.push("\n\n");
+  },"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
+  var stack1, buffer = '';
+  stack1 = helpers['if'].call(depth0, "isOpen", {"name":"if","hash":{},"hashTypes":{},"hashContexts":{},"fn":this.program(1, data),"inverse":this.noop,"types":["ID"],"contexts":[depth0],"data":data});
+  if (stack1 != null) { data.buffer.push(stack1); }
+  data.buffer.push("\n");
   return buffer;
-  
-});
+},"useData":true});

--- a/dist/globals/main.js
+++ b/dist/globals/main.js
@@ -698,80 +698,54 @@ if (!$.expr[':'].tabbable) {
 },{}],7:[function(_dereq_,module,exports){
 "use strict";
 var Ember = window.Ember["default"] || window.Ember;
-exports["default"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
-this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
-  
-
-
+exports["default"] = Ember.Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   data.buffer.push("ic-modal-screen,\nic-modal,\nic-modal-main,\nic-modal-title {\n  display: block;\n}\n\nic-modal,\n.ic-modal-form {\n  display: none;\n  -webkit-overflow-scrolling: touch;\n  position: fixed;\n  bottom: 0;\n  left: 0;\n  right: 0;\n  top: 0;\n  overflow: auto;\n  background-color: hsla(0, 0%, 100%, .90);\n  padding: 10px;\n}\n\nic-modal[is-open],\n.ic-modal-form[is-open] {\n  display: block;\n}\n\nic-modal-main {\n  position: relative;\n  margin: 40px auto;\n  max-width: 800px;\n  padding: 20px;\n  border-radius: 4px;\n  background: #fff;\n  border: 1px solid hsl(0, 0%, 70%);\n}\n\nic-modal-title {\n  margin: 0 -20px 20px -20px;\n  padding: 0 20px 20px 20px;\n  border-bottom: 1px solid hsl(0, 0%, 90%);\n}\n\n.ic-modal-trigger.ic-modal-close {\n  position: absolute;\n  right: 10px;\n  top: 10px;\n  background: none;\n  border: none;\n  color: inherit;\n  font-size: 18px;\n  padding: 6px;\n}\n\n.ic-modal-trigger.ic-modal-close:focus {\n  outline: none;\n  text-shadow: 0 0 6px hsl(208, 47%, 60%),\n    0 0 2px hsl(208, 47%, 60%),\n    0 0 2px hsl(208, 47%, 60%),\n    0 0 1px hsl(208, 47%, 60%);\n}\n\n");
-  
-});
+  },"useData":true});
 },{}],8:[function(_dereq_,module,exports){
 "use strict";
 var Ember = window.Ember["default"] || window.Ember;
-exports["default"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
-this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
-  var buffer = '', stack1, self=this, functionType="function", blockHelperMissing=helpers.blockHelperMissing, helperMissing=helpers.helperMissing;
-
-function program1(depth0,data) {
-  
-  var buffer = '', stack1;
-  data.buffer.push("\n  <ic-modal-main>\n\n    ");
-  stack1 = helpers['if'].call(depth0, "makeTitle", {hash:{},hashTypes:{},hashContexts:{},inverse:self.noop,fn:self.program(2, program2, data),contexts:[depth0],types:["ID"],data:data});
-  if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
-  data.buffer.push("\n\n    ");
-  stack1 = helpers['if'].call(depth0, "makeTrigger", {hash:{},hashTypes:{},hashContexts:{},inverse:self.noop,fn:self.program(5, program5, data),contexts:[depth0],types:["ID"],data:data});
-  if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
-  data.buffer.push("\n\n    ");
-  stack1 = helpers._triageMustache.call(depth0, "yield", {hash:{},hashTypes:{},hashContexts:{},contexts:[depth0],types:["ID"],data:data});
-  if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
+exports["default"] = Ember.Handlebars.template({"1":function(depth0,helpers,partials,data) {
+  var stack1, buffer = '';
+  data.buffer.push("  <ic-modal-main>\n\n");
+  stack1 = helpers['if'].call(depth0, "makeTitle", {"name":"if","hash":{},"hashTypes":{},"hashContexts":{},"fn":this.program(2, data),"inverse":this.noop,"types":["ID"],"contexts":[depth0],"data":data});
+  if (stack1 != null) { data.buffer.push(stack1); }
+  data.buffer.push("\n");
+  stack1 = helpers['if'].call(depth0, "makeTrigger", {"name":"if","hash":{},"hashTypes":{},"hashContexts":{},"fn":this.program(5, data),"inverse":this.noop,"types":["ID"],"contexts":[depth0],"data":data});
+  if (stack1 != null) { data.buffer.push(stack1); }
+  data.buffer.push("\n    ");
+  stack1 = helpers._triageMustache.call(depth0, "yield", {"name":"_triageMustache","hash":{},"hashTypes":{},"hashContexts":{},"types":["ID"],"contexts":[depth0],"data":data});
+  if (stack1 != null) { data.buffer.push(stack1); }
   data.buffer.push("\n\n  </ic-modal-main>\n");
   return buffer;
-  }
-function program2(depth0,data) {
-  
-  var buffer = '', stack1, helper, options;
-  data.buffer.push("\n      ");
-  options={hash:{},hashTypes:{},hashContexts:{},inverse:self.noop,fn:self.program(3, program3, data),contexts:[],types:[],data:data}
-  if (helper = helpers['ic-modal-title']) { stack1 = helper.call(depth0, options); }
-  else { helper = (depth0 && depth0['ic-modal-title']); stack1 = typeof helper === functionType ? helper.call(depth0, options) : helper; }
-  if (!helpers['ic-modal-title']) { stack1 = blockHelperMissing.call(depth0, 'ic-modal-title', {hash:{},hashTypes:{},hashContexts:{},inverse:self.noop,fn:self.program(3, program3, data),contexts:[],types:[],data:data}); }
-  if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
-  data.buffer.push("\n    ");
+},"2":function(depth0,helpers,partials,data) {
+  var stack1, helper, options, functionType="function", helperMissing=helpers.helperMissing, blockHelperMissing=helpers.blockHelperMissing, buffer = '';
+  data.buffer.push("      ");
+  stack1 = ((helper = (helper = helpers['ic-modal-title'] || (depth0 != null ? depth0['ic-modal-title'] : depth0)) != null ? helper : helperMissing),(options={"name":"ic-modal-title","hash":{},"hashTypes":{},"hashContexts":{},"fn":this.program(3, data),"inverse":this.noop,"types":[],"contexts":[],"data":data}),(typeof helper === functionType ? helper.call(depth0, options) : helper));
+  if (!helpers['ic-modal-title']) { stack1 = blockHelperMissing.call(depth0, stack1, options); }
+  if (stack1 != null) { data.buffer.push(stack1); }
+  data.buffer.push("\n");
   return buffer;
-  }
-function program3(depth0,data) {
-  
-  
+},"3":function(depth0,helpers,partials,data) {
   data.buffer.push("Modal Content");
-  }
-
-function program5(depth0,data) {
-  
-  var buffer = '', stack1, helper, options;
-  data.buffer.push("\n      ");
-  stack1 = (helper = helpers['ic-modal-trigger'] || (depth0 && depth0['ic-modal-trigger']),options={hash:{
-    'class': ("ic-modal-close"),
-    'aria-label': ("close")
-  },hashTypes:{'class': "STRING",'aria-label': "STRING"},hashContexts:{'class': depth0,'aria-label': depth0},inverse:self.noop,fn:self.program(6, program6, data),contexts:[],types:[],data:data},helper ? helper.call(depth0, options) : helperMissing.call(depth0, "ic-modal-trigger", options));
-  if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
-  data.buffer.push("\n    ");
+  },"5":function(depth0,helpers,partials,data) {
+  var stack1, helperMissing=helpers.helperMissing, buffer = '';
+  data.buffer.push("      ");
+  stack1 = ((helpers['ic-modal-trigger'] || (depth0 && depth0['ic-modal-trigger']) || helperMissing).call(depth0, {"name":"ic-modal-trigger","hash":{
+    'aria-label': ("close"),
+    'class': ("ic-modal-close")
+  },"hashTypes":{'aria-label': "STRING",'class': "STRING"},"hashContexts":{'aria-label': depth0,'class': depth0},"fn":this.program(6, data),"inverse":this.noop,"types":[],"contexts":[],"data":data}));
+  if (stack1 != null) { data.buffer.push(stack1); }
+  data.buffer.push("\n");
   return buffer;
-  }
-function program6(depth0,data) {
-  
-  
+},"6":function(depth0,helpers,partials,data) {
   data.buffer.push("×");
-  }
-
-  stack1 = helpers['if'].call(depth0, "isOpen", {hash:{},hashTypes:{},hashContexts:{},inverse:self.noop,fn:self.program(1, program1, data),contexts:[depth0],types:["ID"],data:data});
-  if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
-  data.buffer.push("\n\n");
+  },"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
+  var stack1, buffer = '';
+  stack1 = helpers['if'].call(depth0, "isOpen", {"name":"if","hash":{},"hashTypes":{},"hashContexts":{},"fn":this.program(1, data),"inverse":this.noop,"types":["ID"],"contexts":[depth0],"data":data});
+  if (stack1 != null) { data.buffer.push(stack1); }
+  data.buffer.push("\n");
   return buffer;
-  
-});
+},"useData":true});
 },{}]},{},[1])
 (1)
 });

--- a/dist/named-amd/main.js
+++ b/dist/named-amd/main.js
@@ -718,81 +718,55 @@ define("ic-modal/templates/modal-css",
   function(__dependency1__, __exports__) {
     "use strict";
     var Ember = __dependency1__["default"] || __dependency1__;
-    __exports__["default"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
-    this.compilerInfo = [4,'>= 1.0.0'];
-    helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
-      
-
-
+    __exports__["default"] = Ember.Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
       data.buffer.push("ic-modal-screen,\nic-modal,\nic-modal-main,\nic-modal-title {\n  display: block;\n}\n\nic-modal,\n.ic-modal-form {\n  display: none;\n  -webkit-overflow-scrolling: touch;\n  position: fixed;\n  bottom: 0;\n  left: 0;\n  right: 0;\n  top: 0;\n  overflow: auto;\n  background-color: hsla(0, 0%, 100%, .90);\n  padding: 10px;\n}\n\nic-modal[is-open],\n.ic-modal-form[is-open] {\n  display: block;\n}\n\nic-modal-main {\n  position: relative;\n  margin: 40px auto;\n  max-width: 800px;\n  padding: 20px;\n  border-radius: 4px;\n  background: #fff;\n  border: 1px solid hsl(0, 0%, 70%);\n}\n\nic-modal-title {\n  margin: 0 -20px 20px -20px;\n  padding: 0 20px 20px 20px;\n  border-bottom: 1px solid hsl(0, 0%, 90%);\n}\n\n.ic-modal-trigger.ic-modal-close {\n  position: absolute;\n  right: 10px;\n  top: 10px;\n  background: none;\n  border: none;\n  color: inherit;\n  font-size: 18px;\n  padding: 6px;\n}\n\n.ic-modal-trigger.ic-modal-close:focus {\n  outline: none;\n  text-shadow: 0 0 6px hsl(208, 47%, 60%),\n    0 0 2px hsl(208, 47%, 60%),\n    0 0 2px hsl(208, 47%, 60%),\n    0 0 1px hsl(208, 47%, 60%);\n}\n\n");
-      
-    });
+      },"useData":true});
   });
 define("ic-modal/templates/modal",
   ["ember","exports"],
   function(__dependency1__, __exports__) {
     "use strict";
     var Ember = __dependency1__["default"] || __dependency1__;
-    __exports__["default"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
-    this.compilerInfo = [4,'>= 1.0.0'];
-    helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
-      var buffer = '', stack1, self=this, functionType="function", blockHelperMissing=helpers.blockHelperMissing, helperMissing=helpers.helperMissing;
-
-    function program1(depth0,data) {
-      
-      var buffer = '', stack1;
-      data.buffer.push("\n  <ic-modal-main>\n\n    ");
-      stack1 = helpers['if'].call(depth0, "makeTitle", {hash:{},hashTypes:{},hashContexts:{},inverse:self.noop,fn:self.program(2, program2, data),contexts:[depth0],types:["ID"],data:data});
-      if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
-      data.buffer.push("\n\n    ");
-      stack1 = helpers['if'].call(depth0, "makeTrigger", {hash:{},hashTypes:{},hashContexts:{},inverse:self.noop,fn:self.program(5, program5, data),contexts:[depth0],types:["ID"],data:data});
-      if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
-      data.buffer.push("\n\n    ");
-      stack1 = helpers._triageMustache.call(depth0, "yield", {hash:{},hashTypes:{},hashContexts:{},contexts:[depth0],types:["ID"],data:data});
-      if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
+    __exports__["default"] = Ember.Handlebars.template({"1":function(depth0,helpers,partials,data) {
+      var stack1, buffer = '';
+      data.buffer.push("  <ic-modal-main>\n\n");
+      stack1 = helpers['if'].call(depth0, "makeTitle", {"name":"if","hash":{},"hashTypes":{},"hashContexts":{},"fn":this.program(2, data),"inverse":this.noop,"types":["ID"],"contexts":[depth0],"data":data});
+      if (stack1 != null) { data.buffer.push(stack1); }
+      data.buffer.push("\n");
+      stack1 = helpers['if'].call(depth0, "makeTrigger", {"name":"if","hash":{},"hashTypes":{},"hashContexts":{},"fn":this.program(5, data),"inverse":this.noop,"types":["ID"],"contexts":[depth0],"data":data});
+      if (stack1 != null) { data.buffer.push(stack1); }
+      data.buffer.push("\n    ");
+      stack1 = helpers._triageMustache.call(depth0, "yield", {"name":"_triageMustache","hash":{},"hashTypes":{},"hashContexts":{},"types":["ID"],"contexts":[depth0],"data":data});
+      if (stack1 != null) { data.buffer.push(stack1); }
       data.buffer.push("\n\n  </ic-modal-main>\n");
       return buffer;
-      }
-    function program2(depth0,data) {
-      
-      var buffer = '', stack1, helper, options;
-      data.buffer.push("\n      ");
-      options={hash:{},hashTypes:{},hashContexts:{},inverse:self.noop,fn:self.program(3, program3, data),contexts:[],types:[],data:data}
-      if (helper = helpers['ic-modal-title']) { stack1 = helper.call(depth0, options); }
-      else { helper = (depth0 && depth0['ic-modal-title']); stack1 = typeof helper === functionType ? helper.call(depth0, options) : helper; }
-      if (!helpers['ic-modal-title']) { stack1 = blockHelperMissing.call(depth0, 'ic-modal-title', {hash:{},hashTypes:{},hashContexts:{},inverse:self.noop,fn:self.program(3, program3, data),contexts:[],types:[],data:data}); }
-      if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
-      data.buffer.push("\n    ");
+    },"2":function(depth0,helpers,partials,data) {
+      var stack1, helper, options, functionType="function", helperMissing=helpers.helperMissing, blockHelperMissing=helpers.blockHelperMissing, buffer = '';
+      data.buffer.push("      ");
+      stack1 = ((helper = (helper = helpers['ic-modal-title'] || (depth0 != null ? depth0['ic-modal-title'] : depth0)) != null ? helper : helperMissing),(options={"name":"ic-modal-title","hash":{},"hashTypes":{},"hashContexts":{},"fn":this.program(3, data),"inverse":this.noop,"types":[],"contexts":[],"data":data}),(typeof helper === functionType ? helper.call(depth0, options) : helper));
+      if (!helpers['ic-modal-title']) { stack1 = blockHelperMissing.call(depth0, stack1, options); }
+      if (stack1 != null) { data.buffer.push(stack1); }
+      data.buffer.push("\n");
       return buffer;
-      }
-    function program3(depth0,data) {
-      
-      
+    },"3":function(depth0,helpers,partials,data) {
       data.buffer.push("Modal Content");
-      }
-
-    function program5(depth0,data) {
-      
-      var buffer = '', stack1, helper, options;
-      data.buffer.push("\n      ");
-      stack1 = (helper = helpers['ic-modal-trigger'] || (depth0 && depth0['ic-modal-trigger']),options={hash:{
-        'class': ("ic-modal-close"),
-        'aria-label': ("close")
-      },hashTypes:{'class': "STRING",'aria-label': "STRING"},hashContexts:{'class': depth0,'aria-label': depth0},inverse:self.noop,fn:self.program(6, program6, data),contexts:[],types:[],data:data},helper ? helper.call(depth0, options) : helperMissing.call(depth0, "ic-modal-trigger", options));
-      if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
-      data.buffer.push("\n    ");
+      },"5":function(depth0,helpers,partials,data) {
+      var stack1, helperMissing=helpers.helperMissing, buffer = '';
+      data.buffer.push("      ");
+      stack1 = ((helpers['ic-modal-trigger'] || (depth0 && depth0['ic-modal-trigger']) || helperMissing).call(depth0, {"name":"ic-modal-trigger","hash":{
+        'aria-label': ("close"),
+        'class': ("ic-modal-close")
+      },"hashTypes":{'aria-label': "STRING",'class': "STRING"},"hashContexts":{'aria-label': depth0,'class': depth0},"fn":this.program(6, data),"inverse":this.noop,"types":[],"contexts":[],"data":data}));
+      if (stack1 != null) { data.buffer.push(stack1); }
+      data.buffer.push("\n");
       return buffer;
-      }
-    function program6(depth0,data) {
-      
-      
+    },"6":function(depth0,helpers,partials,data) {
       data.buffer.push("×");
-      }
-
-      stack1 = helpers['if'].call(depth0, "isOpen", {hash:{},hashTypes:{},hashContexts:{},inverse:self.noop,fn:self.program(1, program1, data),contexts:[depth0],types:["ID"],data:data});
-      if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
-      data.buffer.push("\n\n");
+      },"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
+      var stack1, buffer = '';
+      stack1 = helpers['if'].call(depth0, "isOpen", {"name":"if","hash":{},"hashTypes":{},"hashContexts":{},"fn":this.program(1, data),"inverse":this.noop,"types":["ID"],"contexts":[depth0],"data":data});
+      if (stack1 != null) { data.buffer.push(stack1); }
+      data.buffer.push("\n");
       return buffer;
-      
-    });
+    },"useData":true});
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ic-modal",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "accessible modal ember component",
   "main": "dist/cjs/main",
   "tags": [

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "broccoli": "0.12.3",
     "broccoli-cli": "0.0.1",
     "broccoli-dist-es6-module": "0.2.1",
-    "broccoli-template-compiler": "git://github.com/rpflorence/broccoli-template-compiler#patch-1",
+    "broccoli-ember-hbs-template-compiler": "git+https://github.com/rwjblue/broccoli-ember-hbs-template-compiler.git#enable-handlebars-2-0",
     "karma": "0.11.14",
     "karma-chrome-launcher": "0.1.2",
     "karma-cli": "0.0.4",


### PR DESCRIPTION
See http://emberjs.com/blog/2014/10/16/handlebars-update.html for details, but Ember 1.9.0 will require the usage of Handlebars 2.0. This PR depends on https://github.com/toranb/broccoli-ember-hbs-template-compiler/pull/6 and bumps the major version (as precompiled templates are not compatible between Handlebars 1.x and 2.0).

In the interim users can specify my branch for usage with Ember 1.9.0 by entering the following in their `bower.json`:

```
 "ic-modal": "rwjblue/ic-modal#ember-1-9-compat"
```
